### PR TITLE
Use SpongeGradle for Sponge plugin Gradle projects

### DIFF
--- a/src/main/java/com/demonwav/mcdev/buildsystem/gradle/GradleBuildSystem.java
+++ b/src/main/java/com/demonwav/mcdev/buildsystem/gradle/GradleBuildSystem.java
@@ -191,6 +191,7 @@ public class GradleBuildSystem extends BuildSystem {
                                 project,
                                 gradleProp,
                                 groupId,
+                                artifactId,
                                 version,
                                 buildVersion
                         );
@@ -677,7 +678,7 @@ public class GradleBuildSystem extends BuildSystem {
             });
 
             // it knows which dependencies are needed for each configuration
-            MinecraftProjectCreator.addDependencies(configuration, gradleBuildSystem.repositories, gradleBuildSystem.dependencies);
+            MinecraftProjectCreator.addDependencies(configuration, gradleBuildSystem);
 
             // For each build system we initialize it, but not the same as a normal create. We need to know the common
             // project name, as we automatically add it as a dependency too

--- a/src/main/java/com/demonwav/mcdev/platform/sponge/SpongeProjectConfiguration.java
+++ b/src/main/java/com/demonwav/mcdev/platform/sponge/SpongeProjectConfiguration.java
@@ -1,6 +1,7 @@
 package com.demonwav.mcdev.platform.sponge;
 
 import com.demonwav.mcdev.buildsystem.BuildSystem;
+import com.demonwav.mcdev.buildsystem.gradle.GradleBuildSystem;
 import com.demonwav.mcdev.platform.PlatformType;
 import com.demonwav.mcdev.platform.ProjectConfiguration;
 import com.demonwav.mcdev.util.Util;
@@ -111,7 +112,10 @@ public class SpongeProjectConfiguration extends ProjectConfiguration {
         String annotationString = "@Plugin(";
         annotationString += "\nid = \"" + buildSystem.getArtifactId().toLowerCase() + "\"";
         annotationString += ",\nname = \"" + pluginName + "\"";
-        annotationString += ",\nversion = \"" + buildSystem.getVersion() + "\"";
+        if (!(buildSystem instanceof GradleBuildSystem)) {
+            // SpongeGradle will automatically set the Gradle version as plugin version
+            annotationString += ",\nversion = \"" + buildSystem.getVersion() + "\"";
+        }
 
         if (!Strings.isNullOrEmpty(description)) {
             annotationString += ",\ndescription = \"" + description + "\"";

--- a/src/main/java/com/demonwav/mcdev/platform/sponge/SpongeTemplate.java
+++ b/src/main/java/com/demonwav/mcdev/platform/sponge/SpongeTemplate.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Properties;
 
 public class SpongeTemplate extends AbstractTemplate {
@@ -62,19 +63,22 @@ public class SpongeTemplate extends AbstractTemplate {
     public static String applyBuildGradleTemplate(@NotNull Project project,
                                                   @NotNull VirtualFile file,
                                                   @NotNull String groupId,
+                                                  @NotNull String artifactId,
                                                   @NotNull String pluginVersion,
                                                   @NotNull String buildVersion) {
 
         Properties properties = new Properties();
-        properties.setProperty("GROUP_ID", groupId);
-        properties.setProperty("PLUGIN_VERSION", pluginVersion);
-        properties.setProperty("BUILD_VERSION", buildVersion);
+        // Only set build version if it is higher/lower than 1.8 (SpongeGradle automatically sets it to 1.8)
+        if (!buildVersion.equals("1.8")) {
+            properties.setProperty("BUILD_VERSION", buildVersion);
+        }
 
         FileTemplateManager manager = FileTemplateManager.getInstance(project);
         FileTemplate template = manager.getJ2eeTemplate(MinecraftFileTemplateGroupFactory.SPONGE_BUILD_GRADLE_TEMPLATE);
 
         Properties gradleProps = new Properties();
         gradleProps.setProperty("GROUP_ID", groupId);
+        gradleProps.setProperty("PLUGIN_ID", artifactId.toLowerCase(Locale.ENGLISH));
         gradleProps.setProperty("PLUGIN_VERSION", pluginVersion);
 
         try {

--- a/src/main/resources/fileTemplates/j2ee/sponge_build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge_build.gradle.ft
@@ -1,26 +1,25 @@
 plugins {
+    id 'org.spongepowered.plugin' version '0.7'
     id "com.qixalite.spongestart" version "1.5.2"
-    id "java"
 }
 
-group pluginGroup
-version pluginVersion
+group = pluginGroup
+version = pluginVersion
 
+#if (${BUILD_VERSION})
 sourceCompatibility = ${BUILD_VERSION}
 targetCompatibility = ${BUILD_VERSION}
 
-spongestart{
+#end
+dependencies {
+}
+
+sponge.plugin.id = pluginId
+
+spongestart {
     eula true
 
     //optional configs
     spongeVanillaBuild 'LATEST'
     vanillaServerFolder project.file('run/vanilla').getAbsolutePath()
-}
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.11'
 }

--- a/src/main/resources/fileTemplates/j2ee/sponge_gradle.properties.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge_gradle.properties.ft
@@ -1,5 +1,3 @@
 pluginGroup = ${GROUP_ID}
+pluginId = ${PLUGIN_ID}
 pluginVersion = ${PLUGIN_VERSION}
-
-minecraftVersion=${MINECRAFT_VERSION}
-mcpMappings=${MCP_MAPPINGS}

--- a/src/main/resources/fileTemplates/j2ee/sponge_main_class.java.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge_main_class.java.ft
@@ -55,4 +55,5 @@ public class ${CLASS_NAME} {
         // The text message could be configurable, check the docs on how to do so!
         player.sendMessage(Text.of(TextColors.AQUA, TextStyles.BOLD, "Hi " + player.getName()));
     }
+
 }

--- a/src/main/resources/fileTemplates/j2ee/sponge_submodule_build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge_submodule_build.gradle.ft
@@ -1,13 +1,9 @@
 plugins {
+    id 'org.spongepowered.plugin' version '0.7'
     id "com.qixalite.spongestart" version "1.5.2"
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.11'
     compile project(':${COMMON_PROJECT_NAME}')
 }
 
@@ -17,7 +13,7 @@ processResources {
     }
 }
 
-spongestart{
+spongestart {
     eula true
 
     //optional configs


### PR DESCRIPTION
[SpongeGradle](https://docs.spongepowered.org/master/en/plugin/project/gradle.html#using-spongegradle) is a Gradle plugin that automatically sets a lot of defaults for Sponge plugins using Gradle. The primary feature is that it automatically sets the plugin version defined in the Gradle build file to the generated plugin metadata, so plugin authors will only need to update their version in one place.

This PR changes the Sponge Gradle templates to automatically apply SpongeGradle and removes all settings that are automatically applied by SpongeGradle.

Let me know if any changes are necessary before this can be merged. :)